### PR TITLE
Fix the reset to CGAffineTransformIdentity not being animated

### DIFF
--- a/UIView-Shake/UIView+Shake.m
+++ b/UIView-Shake/UIView+Shake.m
@@ -31,7 +31,9 @@
 		self.layer.affineTransform = (shakeDirection == ShakeDirectionHorizontal) ? CGAffineTransformMakeTranslation(delta * direction, 0) : CGAffineTransformMakeTranslation(0, delta * direction);
 	} completion:^(BOOL finished) {
 		if(current >= times) {
-			self.layer.affineTransform = CGAffineTransformIdentity;
+			[UIView animateWithDuration:interval animations:^{
+				self.layer.affineTransform = CGAffineTransformIdentity;
+			}];
 			return;
 		}
 		[self _shake:(times - 1)


### PR DESCRIPTION
When reseting the view to its original position with `CGAffineTransformIdentity`, the change is not animated, which makes the view "jump" at the end of the animation.

Before fix: https://dl.dropboxusercontent.com/u/18386288/UIView%2BShake_before.mov
After fix: https://dl.dropboxusercontent.com/u/18386288/UIView%2BShake_after.mov

(sorry, .mov videos, could not find a satisfying gif converter...)

Also, please note that the first and last animations are executed with the same duration as all the others shakes, but the distance travelled by the view is 2x smaller, making these appear "slower".

Issue mirrored for UITextField+Shake here: https://github.com/andreamazz/UITextField-Shake/pull/5
