### PR TITLE
Fix crash resulting from failure to guard against nil completion handler

### DIFF
--- a/UIView-Shake/UIView+Shake.m
+++ b/UIView-Shake/UIView+Shake.m
@@ -39,7 +39,9 @@
 			[UIView animateWithDuration:interval animations:^{
 				self.layer.affineTransform = CGAffineTransformIdentity;
 			} completion:^(BOOL finished){
-				completionHandler();
+				if (completionHandler != nil) {
+					completionHandler();
+				}
 			}];
 			return;
 		}


### PR DESCRIPTION
The addition of an unguarded completion handler in the 0.4 release results in a crash (`EXC_BAD_ACCESS`) when the completion handler is nil (i.e. the default when not using the new method).

This PR adds a nil check to guard against this.