### PR TITLE
import UIKit in header file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ UIView category that adds a shake animation like the password field of the OSX l
 * Run ```open App.xcworkspace```
 
 ###Objective-C
-Import ```UIVIew+Shake.h``` in your controller's header file
+Import ```UIView+Shake.h``` in your controller's header file
 ###Swift
 If you are using `use_frameworks!` in your Podfile, use this import:
 ```swift

--- a/UIView-Shake/UIView+Shake.h
+++ b/UIView-Shake/UIView+Shake.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 Fancy Pixel. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
 typedef NS_ENUM(NSInteger, ShakeDirection) {
     ShakeDirectionHorizontal = 0,
     ShakeDirectionVertical


### PR DESCRIPTION
You should always add UIKit to your header files if needed. So no UIKit or predefinition is needed when using UIView+Shake.h

(plus: AppCode adds the automatic imported header files always to the top row so another manual step is needed or it will not compile)