### PR TITLE
Enabled bit code for both build and archive

### DIFF
--- a/UIView+Shake.xcodeproj/project.pbxproj
+++ b/UIView+Shake.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -212,6 +213,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Enabled bit code for both build and archive. As a side effect this makes the library support bit code enabled projects that use Carthage

For reference follow https://github.com/Carthage/Carthage/issues/535

if BITCODE_GENERATION_MODE is not set to bitcode, projects using carthage will not be able to submit apps to appstore (or just archive them) even when enable bitcode setting is set to yes. Explanation in the link above. 

The library is used in www.monogram.me