### PR TITLE
Replace `direction` with `shakeDirection` in documentation comments

### DIFF
--- a/Source/UIView+Shake.h
+++ b/Source/UIView+Shake.h
@@ -79,7 +79,7 @@ typedef NS_ENUM(NSInteger, ShakeDirection) {
  * @param times The number of shakes
  * @param delta The width of the shake
  * @param interval The duration of one shake
- * @param direction of the shake
+ * @param shakeDirection of the shake
  */
 - (void)shake:(int)times withDelta:(CGFloat)delta speed:(NSTimeInterval)interval shakeDirection:(ShakeDirection)shakeDirection;
 
@@ -90,7 +90,7 @@ typedef NS_ENUM(NSInteger, ShakeDirection) {
  * @param times The number of shakes
  * @param delta The width of the shake
  * @param interval The duration of one shake
- * @param direction of the shake
+ * @param shakeDirection of the shake
  * @param completion to be called when the view is done shaking
  */
 - (void)shake:(int)times withDelta:(CGFloat)delta speed:(NSTimeInterval)interval shakeDirection:(ShakeDirection)shakeDirection completion:(nullable void (^)(void))completion;


### PR DESCRIPTION
The documentation comments were out of sync with the actual name of the arguments for two methods, raising a warning with the `-Wdocumentation` compiler flag.